### PR TITLE
Fix exception in mathler

### DIFF
--- a/wordle/guess/exhaustive.py
+++ b/wordle/guess/exhaustive.py
@@ -81,6 +81,6 @@ class Exhaustive(GuessingAlgorithm):
 
     @classmethod
     def _get_possible_guesses(cls, remaining_words, possible_guesses):
-        if len(remaining_words) <= 50:
+        if len(remaining_words) <= 50 and len(possible_guesses) != 0:
             return possible_guesses
         return remaining_words


### PR DESCRIPTION
I found a case in play_nerdle, but I suspect it might affect all of mathler, where Solver.solve could end up with remianing_words being <= 50. Since Solver.guesses never seems to get populated for mathler, when remaining_words is <= 50, Exhaustive._get_possible_answers returns []. When this happens Solver.solve() throws an AttributeError when it attempts to call .upper() on None.

This change simply checks to ensure that Exhaustive._get_possible_answers() doesn't return [] when there are possible answers to return.